### PR TITLE
chore: add ens setName call

### DIFF
--- a/script/community/Community_2024_06_11_SetENSName.s.sol
+++ b/script/community/Community_2024_06_11_SetENSName.s.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+import { CoveToken } from "cove-contracts-boosties/src/governance/CoveToken.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { CommunityMultisigScript } from "./CommunityMultisigScript.s.sol";
+import { StdAssertions } from "forge-std/StdAssertions.sol";
+
+interface ReverseRegistrar {
+    function setName(string calldata name) external;
+}
+
+contract Script is CommunityMultisigScript, StdAssertions {
+    function run(bool shouldSend) public override {
+        super.run(shouldSend);
+        address reverseRegistrar = 0xa58E81fe9b61B5c3fE2AFD33CF304c454AbFc7Cb;
+        // ================================ START BATCH ===================================
+        // Add to batch
+        addToBatch(reverseRegistrar, 0, abi.encodeCall(ReverseRegistrar.setName, ("community.covefi.eth")));
+        // ============================= QUEUE UP MSIG ================================
+        if (shouldSend) {
+            executeBatch(true);
+        }
+    }
+}


### PR DESCRIPTION
```rust
├─ [0] VM::prank(0x7Bd578354b0B2f02E656f1bDC0e41a80f860534b)
    │   └─ ← [Return] 
    ├─ [92524] 0xa58E81fe9b61B5c3fE2AFD33CF304c454AbFc7Cb::setName("community.covefi.eth")
    │   ├─ emit ReverseClaimed(param0: 0x7Bd578354b0B2f02E656f1bDC0e41a80f860534b, param1: 0x0036757ef2212137fc6614549a85c09239612df95856bfd4953d24ed2c8df6d1)
    │   ├─ [51440] 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e::setSubnodeRecord(0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2, 0xcb1b5dde16ab14b6d243611be316d77b32e4fb770adf1e4df30b8fb4212ea539, 0x7Bd578354b0B2f02E656f1bDC0e41a80f860534b, 0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63, 0)
    │   │   ├─  emit topic 0: 0xce0457fe73731f824cc272376169235128c118b49d344817417c6d108d155e82
    │   │   │       topic 1: 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2
    │   │   │       topic 2: 0xcb1b5dde16ab14b6d243611be316d77b32e4fb770adf1e4df30b8fb4212ea539
    │   │   │           data: 0x0000000000000000000000007bd578354b0b2f02e656f1bdc0e41a80f860534b
    │   │   ├─ emit NewResolver(param0: 0x000000000000000000000000231b0ee14048e9dccd1d247744d114a4eb5e8e63, param1: 0x9a85C09239612Df95856bFD4953D24eD2C8Df6d1)
    │   │   └─ ← [Stop] 
    │   ├─ [27659] 0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63::setName(0x0036757ef2212137fc6614549a85c09239612df95856bfd4953d24ed2c8df6d1, "community.covefi.eth")
    │   │   ├─ emit NameChanged(param0: 0x0000000000000000000000000000000000000000000000000000000000000020, param1: "")
    │   │   └─ ← [Stop] 
    │   └─ ← [Return] 0x0036757ef2212137fc6614549a85c09239612df95856bfd4953d24ed2c8df6d1
    
```