### PR TITLE
feat: epoch8 rewards transfer to operations multisig

### DIFF
--- a/script/community/Community_2025_03_31_Epoch8LMIncentives.s.sol
+++ b/script/community/Community_2025_03_31_Epoch8LMIncentives.s.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+import { CoveToken } from "cove-contracts-boosties/src/governance/CoveToken.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { CommunityMultisigScript } from "./CommunityMultisigScript.s.sol";
+import { StdAssertions } from "forge-std/StdAssertions.sol";
+
+contract Script is CommunityMultisigScript, StdAssertions {
+    function run(bool shouldSend) public override {
+        super.run(shouldSend);
+
+        // https://docs.cove.finance/ecosystem/token/liquidity-mining#epoch-8
+        // 2MM per month, total 4MM for 2 months
+        uint256 totalRewards = 4_000_000 ether;
+        address coveToken = deployer.getAddress("CoveToken");
+
+        uint256 communityBalanceBefore = CoveToken(coveToken).balanceOf(MAINNET_COVE_COMMUNITY_MULTISIG);
+        uint256 opsBalanceBefore = CoveToken(coveToken).balanceOf(MAINNET_COVE_OPS_MULTISIG);
+
+        // ================================ START BATCH ===================================
+        // Add to batch
+        addToBatch(coveToken, 0, abi.encodeCall(IERC20.transfer, (MAINNET_COVE_OPS_MULTISIG, totalRewards)));
+
+        // ================================ TESTING ===================================
+        uint256 communityBalanceAfter = CoveToken(coveToken).balanceOf(MAINNET_COVE_COMMUNITY_MULTISIG);
+        uint256 opsBalanceAfter = CoveToken(coveToken).balanceOf(MAINNET_COVE_OPS_MULTISIG);
+        assertEq(
+            communityBalanceBefore - communityBalanceAfter,
+            totalRewards,
+            "Community balance should decrease by the total rewards sent"
+        );
+        assertEq(
+            opsBalanceAfter - opsBalanceBefore,
+            totalRewards,
+            "Operations multisig should have received the total rewards in Cove tokens"
+        );
+        // ============================= QUEUE UP MSIG ================================
+        if (shouldSend) {
+            executeBatch(true);
+        }
+    }
+}


### PR DESCRIPTION
https://docs.cove.finance/ecosystem/token/liquidity-mining#epoch-8
```
    ├─ [17661] 0x32fb7D6E0cBEb9433772689aA4647828Cc7cbBA8::transfer(0x71BDC5F3AbA49538C76d58Bc2ab4E3A1118dAe4c, 4000000000000000000000000 [4e24])
    │   ├─ emit Transfer(from: 0x7Bd578354b0B2f02E656f1bDC0e41a80f860534b, to: 0x71BDC5F3AbA49538C76d58Bc2ab4E3A1118dAe4c, value: 4000000000000000000000000 [4e24])
    │   └─ ← [Return] true
    ├─ [651] 0x32fb7D6E0cBEb9433772689aA4647828Cc7cbBA8::balanceOf(0x7Bd578354b0B2f02E656f1bDC0e41a80f860534b) [staticcall]
    │   └─ ← [Return] 128781731398525314835022625 [1.287e26]
    ├─ [651] 0x32fb7D6E0cBEb9433772689aA4647828Cc7cbBA8::balanceOf(0x71BDC5F3AbA49538C76d58Bc2ab4E3A1118dAe4c) [staticcall]
    │   └─ ← [Return] 4000000000000000000000012 [4e24]
    ├─ [0] VM::assertEq(4000000000000000000000000 [4e24], 4000000000000000000000000 [4e24], "Community balance should decrease by the total rewards sent") [staticcall]
    │   └─ ← [Return] 
    ├─ [0] VM::assertEq(4000000000000000000000000 [4e24], 4000000000000000000000000 [4e24], "Operations multisig should have received the total rewards in Cove tokens") [staticcall]
    │   └─ ← [Return] 
    └─ ← [Stop] 
```