### PR TITLE
Update pull request in multisig-scripts

### DIFF
--- a/script/community/Community_2025_06_16_SetDYFIRedeemer.s.sol
+++ b/script/community/Community_2025_06_16_SetDYFIRedeemer.s.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.18;
 
 import { CommunityMultisigScript } from "./CommunityMultisigScript.s.sol";
 import { StdAssertions } from "forge-std/StdAssertions.sol";
+import { CoveYearnGaugeFactory } from "cove-contracts-boosties/src/registries/CoveYearnGaugeFactory.sol";
+import { YearnGaugeStrategy } from "cove-contracts-boosties/src/strategies/YearnGaugeStrategy.sol";
 
 interface IDYFIRedeemer {
     function kill() external;
@@ -24,9 +26,20 @@ contract Script is CommunityMultisigScript, StdAssertions {
         address dyfiRedeemerV2 = 0x0000000000000000000000000000000000000000;
         address dyfiRedeemer = 0x986F38B5b096070eE64B12Da762468606C8B0706;
         address masterRegistry = 0x91cf20C03bEC656BC008fB2a2177bC3caA34f772;
+        // Fetch all Yearn gauge info from the factory
+        CoveYearnGaugeFactory factory = CoveYearnGaugeFactory(deployer.getAddress("CoveYearnGaugeFactory"));
+        CoveYearnGaugeFactory.GaugeInfo[] memory gauges = factory.getAllGaugeInfo(100, 0);
         // ================================ START BATCH ===================================
-        // Add to batch
+        // Add to batch - update SwapAndLock contract
         addToBatch(swapAndLock, 0, abi.encodeCall(ISwapAndLock.setDYfiRedeemer, dyfiRedeemerV2));
+        // Update every YearnGaugeStrategy with the new (placeholder) redeemer address
+        for (uint256 i = 0; i < gauges.length; i++) {
+            addToBatch(
+                gauges[i].coveYearnStrategy,
+                0,
+                abi.encodeCall(YearnGaugeStrategy.setDYfiRedeemer, (dyfiRedeemerV2))
+            );
+        }
         // Kill old redeemer
         addToBatch(dyfiRedeemer, 0, abi.encodeCall(IDYFIRedeemer.kill, ()));
         // Add new contract to master registry


### PR DESCRIPTION
The script `script/community/Community_2025_06_16_SetDYFIRedeemer.s.sol` was updated to broaden its scope for redeemer address management.

*   Imports for `CoveYearnGaugeFactory` and `YearnGaugeStrategy` were added.
*   The `CoveYearnGaugeFactory` was used to call `factory.getAllGaugeInfo(100, 0)`, retrieving details for all Yearn gauges.
*   A loop was introduced to iterate through the returned gauge information. For each `coveYearnStrategy` found, a call to `setDYfiRedeemer` was batched, using the designated zero-address placeholder.
*   This ensures that all Yearn gauge strategies are updated with the new redeemer address, in addition to the existing actions for the `SwapAndLock` contract, the killing of the old redeemer, and the master registry update. All operations remain within a single batch.