### PR TITLE
chore: add merkl distributor contract as a sender for future epochs

### DIFF
--- a/script/community/Community_2025_06_27_TransferLMRewardsMerkl.s.sol
+++ b/script/community/Community_2025_06_27_TransferLMRewardsMerkl.s.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+import { CommunityMultisigScript } from "./CommunityMultisigScript.s.sol";
+import { StdAssertions } from "forge-std/StdAssertions.sol";
+import { TimelockController } from
+    "lib/cove-contracts-boosties/lib/openzeppelin-contracts/contracts/governance/TimelockController.sol";
+import { CoveToken } from "lib/cove-contracts-boosties/src/governance/CoveToken.sol";
+import { IERC20 } from "lib/cove-contracts-boosties/lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+// Transfer COVE tokens to ops multisig for future LM programs.
+// Allow merklDistributor address to send COVE tokens, allowing user claims.
+// Roughly 30.13 million $COVE (≈ 3.01 % of the 1 B total supply) have been emitted across Season 1 and the single
+// completed epoch of Season 2. Because 8 % of supply (80 M $COVE) was budgeted for liquidity-mining, about 49.87
+// million $COVE remain un-allocated.
+contract Script is CommunityMultisigScript, StdAssertions {
+    address constant MERKL_DISTRIBUTOR = 0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae;
+    uint256 totalLMRewards = 49_869_200e18;
+
+    function run() public {
+        run(false);
+    }
+
+    function run(bool shouldSend) public override {
+        super.run(shouldSend);
+        address timelock = deployer.getAddress("TimelockController");
+        address coveToken = deployer.getAddress("CoveToken");
+
+        // ================================ START BATCH ===================================
+        address target = MERKL_DISTRIBUTOR;
+        uint256 value = 0;
+        bytes memory payload = abi.encodeCall(CoveToken.addAllowedSender, (MERKL_DISTRIBUTOR));
+
+        addToBatch(
+            timelock,
+            0,
+            abi.encodeCall(TimelockController.schedule, (target, value, payload, bytes32(0), bytes32(0), 2 days))
+        );
+        addToBatch(coveToken, 0, abi.encodeCall(IERC20.transfer, (MAINNET_COVE_OPS_MULTISIG, totalLMRewards)));
+
+        // ============================= TESTING ===================================
+        // Warp to end of timelock period
+        vm.warp(block.timestamp + 2 days);
+
+        // Execute timelock
+        vm.prank(MAINNET_COVE_DEPLOYER);
+        TimelockController(payable(timelock)).execute(target, value, payload, bytes32(0), bytes32(0));
+
+        // Check MERKL_DISTRIBUTOR is an allowed sender of COVE tokens
+        assertTrue(CoveToken(coveToken).allowedSender(MERKL_DISTRIBUTOR));
+
+        // ============================= QUEUE UP MSIG ================================
+        if (shouldSend) {
+            executeBatch(true);
+        }
+    }
+}

--- a/script/deployer/Deployer_2025_06_29_ExecuteTimelock.s.sol
+++ b/script/deployer/Deployer_2025_06_29_ExecuteTimelock.s.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+import { CoveToken } from "lib/cove-contracts-boosties/src/governance/CoveToken.sol";
+import { DeployerScript } from "./DeployerScript.s.sol";
+import { TimelockController } from
+    "lib/cove-contracts-boosties/lib/openzeppelin-contracts/contracts/governance/TimelockController.sol";
+
+// Execute the timelock transaction scheduled by Community_2025_06_27_TransferLMRewardsMerkl
+// This will call CoveToken.addAllowedSender(merklDistributor) to allow Merkl to distribute COVE tokens
+contract Script is DeployerScript {
+    address constant MERKL_DISTRIBUTOR = 0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae;
+
+    function run() public override {
+        super.run();
+        vm.startBroadcast(MAINNET_COVE_DEPLOYER);
+
+        address coveToken = deployer.getAddress("CoveToken");
+        address timelock = deployer.getAddress("TimelockController");
+
+        // Execute the scheduled timelock transaction
+        address target = coveToken;
+        uint256 value = 0;
+        bytes memory payload = abi.encodeCall(CoveToken.addAllowedSender, (MERKL_DISTRIBUTOR));
+
+        TimelockController(payable(timelock)).execute(target, value, payload, bytes32(0), bytes32(0));
+
+        vm.stopBroadcast();
+    }
+}


### PR DESCRIPTION
This pull request introduces two new scripts to manage and execute the distribution of liquidity-mining (LM) rewards for the COVE token. The changes focus on scheduling and executing a timelock transaction to allow the Merkl Distributor to distribute COVE tokens and transferring unallocated LM rewards to a multisig wallet.

### New Scripts for Liquidity-Mining Rewards Management:

* **Script for Scheduling Timelock Transaction**:
  - Added `Community_2025_06_27_TransferLMRewardsMerkl.s.sol` to schedule a timelock transaction that enables the Merkl Distributor to send COVE tokens and transfers approximately 49.87 million unallocated LM rewards to the operations multisig wallet.

* **Script for Executing Timelock Transaction**:
  - Added `Deployer_2025_06_29_ExecuteTimelock.s.sol` to execute the scheduled timelock transaction, allowing the Merkl Distributor to distribute COVE tokens by calling `CoveToken.addAllowedSender`.